### PR TITLE
Improve Translator's Note

### DIFF
--- a/src/epub/text/translator-note.xhtml
+++ b/src/epub/text/translator-note.xhtml
@@ -26,10 +26,10 @@
 					<p><i epub:type="se:name.publication.book">Abraham</i>: Translated into French by <abbr epub:type="z3998:given-name">C.</abbr> Cuzin, with critical preface.</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book" xml:lang="fr">Theatre de Roswitha</i>: Charles Magnin.</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="fr">Théâtre de Roswitha</i>: Charles Magnin.</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book" xml:lang="fr">Origines du theatre Moderne</i>: Charles Magnin.</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="fr">Origines du théâtre Moderne</i>: Charles Magnin.</p>
 				</li>
 				<li>
 					<p><i epub:type="se:name.publication.book" xml:lang="la">Antiquitates Gandersheimensis</i>: Leuckfeld.</p>

--- a/src/epub/text/translator-note.xhtml
+++ b/src/epub/text/translator-note.xhtml
@@ -11,28 +11,28 @@
 			<p>The works consulted include the following:</p>
 			<ul>
 				<li>
-					<p><i epub:type="se:name.publication.book">Hrotsvithae Opera</i>: Edited by Paul Winterfeld.</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="la">Hrotsvithae Opera</i>: Edited by Paul Winterfeld.</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book">Hrotsvithae Opera</i>: Edited by <abbr epub:type="z3998:given-name">H. L.</abbr> Schurzfleisch.</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="la">Hrotsvithae Opera</i>: Edited by <abbr epub:type="z3998:given-name">H. L.</abbr> Schurzfleisch.</p>
 				</li>
 				<li>
-					<p><i>Hrotsvithae Opera</i>: Edited by Conrad Celtes (Nurnberg, 1 501).</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="la">Hrotsvithae Opera</i>: Edited by Conrad Celtes (Nurnberg, 1 501).</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book">Patrologiae Cursus Completus</i>: <abbr epub:type="z3998:given-name">J. P.</abbr> Migne (<abbr>vol.</abbr> 137).</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="la">Patrologiae Cursus Completus</i>: <abbr epub:type="z3998:given-name">J. P.</abbr> Migne (<abbr>vol.</abbr> 137).</p>
 				</li>
 				<li>
 					<p><i epub:type="se:name.publication.book">Abraham</i>: Translated into French by <abbr epub:type="z3998:given-name">C.</abbr> Cuzin, with critical preface.</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book">Theatre de Roswitha</i>: Charles Magnin.</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="fr">Theatre de Roswitha</i>: Charles Magnin.</p>
 				</li>
 				<li>
 					<p><i epub:type="se:name.publication.book" xml:lang="fr">Origines du theatre Moderne</i>: Charles Magnin.</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book">Antiquitates Gandersheimensis</i>: Leuckfeld.</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="la">Antiquitates Gandersheimensis</i>: Leuckfeld.</p>
 				</li>
 				<li>
 					<p><i epub:type="se:name.publication.book">Six Medieval Women</i>: Alice Kemp Welch.</p>

--- a/src/epub/text/translator-note.xhtml
+++ b/src/epub/text/translator-note.xhtml
@@ -17,7 +17,7 @@
 					<p><i epub:type="se:name.publication.book" xml:lang="la">Hrotsvithae Opera</i>: Edited by <abbr epub:type="z3998:given-name">H. L.</abbr> Schurzfleisch.</p>
 				</li>
 				<li>
-					<p><i epub:type="se:name.publication.book" xml:lang="la">Hrotsvithae Opera</i>: Edited by Conrad Celtes (Nurnberg, 1 501).</p>
+					<p><i epub:type="se:name.publication.book" xml:lang="la">Hrotsvithae Opera</i>: Edited by Conrad Celtes (Nurnberg, 1501).</p>
 				</li>
 				<li>
 					<p><i epub:type="se:name.publication.book" xml:lang="la">Patrologiae Cursus Completus</i>: <abbr epub:type="z3998:given-name">J. P.</abbr> Migne (<abbr>vol.</abbr> 137).</p>


### PR DESCRIPTION
`Hrotsvithae Opera` is Latin for 'The Works of Roswitha', but it hadn't been marked as Latin. And French-language book titles were missing accents present in the scans.